### PR TITLE
Remove G-buffer pass and unused keywords

### DIFF
--- a/Runtime/SRP/VXGIRenderer.cs
+++ b/Runtime/SRP/VXGIRenderer.cs
@@ -3,22 +3,6 @@ using UnityEngine.Rendering;
 using UnityEngine.Experimental.Rendering;
 
 public class VXGIRenderer : System.IDisposable {
-  public enum ConeType {
-    All,
-    Diffuse,
-    Reflectance,
-    Transmittance
-  }
-
-  public enum GBufferType {
-    Diffuse,
-    Depth,
-    Normal,
-    Emission,
-    Glossiness,
-    Metallic
-  }
-
   public enum MipmapSampler {
     Linear,
     Point
@@ -27,8 +11,7 @@ public class VXGIRenderer : System.IDisposable {
   public enum Pass {
     ConeTracing = 0,
     DiffuseConeTracing = 1,
-    GBuffer = 2,
-    Mipmap = 3
+    Mipmap = 2
   }
 
   public Material material {
@@ -50,10 +33,8 @@ public class VXGIRenderer : System.IDisposable {
   CommandBuffer _command;
   CommandBuffer _commandDiffuse;
   CommandBuffer _commandReflection;
-  ConeType _coneType;
   CullResults _cullResults;
   FilterRenderersSettings _filterSettings;
-  GBufferType _gBufferType = GBufferType.Diffuse;
   Material _material;
 
   public VXGIRenderer() {
@@ -113,22 +94,6 @@ public class VXGIRenderer : System.IDisposable {
     if (vxgi.pass == Pass.ConeTracing) {
       renderContext.SetupCameraProperties(camera);
       renderContext.DrawSkybox(camera);
-    }
-
-    if (_gBufferType != vxgi.gBufferType) {
-      _command.DisableShaderKeyword(GetGBufferKeyword(_gBufferType));
-      _command.EnableShaderKeyword(GetGBufferKeyword(vxgi.gBufferType));
-      _gBufferType = vxgi.gBufferType;
-    }
-
-    if (_coneType != vxgi.coneType) {
-      var keyword = GetConeKeyword(_coneType);
-      if (keyword != null) _command.DisableShaderKeyword(keyword);
-
-      keyword = GetConeKeyword(vxgi.coneType);
-      if (keyword != null) _command.EnableShaderKeyword(keyword);
-
-      _coneType = vxgi.coneType;
     }
 
     Matrix4x4 clipToWorld = camera.cameraToWorldMatrix * GL.GetGPUProjectionMatrix(camera.projectionMatrix, false).inverse;
@@ -200,26 +165,5 @@ public class VXGIRenderer : System.IDisposable {
     renderContext.ExecuteCommandBuffer(_command);
 
     _command.Clear();
-  }
-
-  string GetConeKeyword(ConeType type) {
-    switch (type) {
-      case ConeType.Diffuse: return "TRACE_DIFFUSE";
-      case ConeType.Reflectance: return "TRACE_REFLECTANCE";
-      case ConeType.Transmittance: return "TRACE_TRANSMITTANCE";
-      default: return null;
-    }
-  }
-
-  string GetGBufferKeyword(GBufferType type) {
-    switch (type) {
-      case GBufferType.Diffuse: return "GBUFFER_DIFFUSE";
-      case GBufferType.Depth: return "GBUFFER_DEPTH";
-      case GBufferType.Normal: return "GBUFFER_NORMAL";
-      case GBufferType.Emission: return "GBUFFER_EMISSION";
-      case GBufferType.Glossiness: return "GBUFFER_GLOSSINESS";
-      case GBufferType.Metallic: return "GBUFFER_METALLIC";
-      default: return "GBUFFER_DIFFUSE";
-    }
   }
 }

--- a/Runtime/VXGI.cs
+++ b/Runtime/VXGI.cs
@@ -21,8 +21,6 @@ public class VXGI : MonoBehaviour {
   [Range(1f, 100f)]
   public float tracingRate = 10f;
   public VXGIRenderer.Pass pass = VXGIRenderer.Pass.ConeTracing;
-  public VXGIRenderer.ConeType coneType = VXGIRenderer.ConeType.All;
-  public VXGIRenderer.GBufferType gBufferType = VXGIRenderer.GBufferType.Diffuse;
   public VXGIRenderer.MipmapSampler mipmapSampler = VXGIRenderer.MipmapSampler.Linear;
   [Range(0f, 9f)]
   public float level = 1f;

--- a/Shaders/VXGI.shader
+++ b/Shaders/VXGI.shader
@@ -19,7 +19,6 @@ Shader "Hidden/VXGI"
       #pragma vertex vert
       #pragma fragment frag
       #pragma multi_compile __ TRACE_SUN
-      #pragma multi_compile __ TRACE_DIFFUSE TRACE_REFLECTANCE TRACE_TRANSMITTANCE
 
       #include "UnityCG.cginc"
       #include "Packages/com.looooong.srp.vxgi/ShaderLibrary/Radiances/Pixel.cginc"
@@ -142,73 +141,6 @@ Shader "Hidden/VXGI"
         }
 
         return color;
-      }
-      ENDCG
-    }
-
-    Pass
-    {
-      Name "GBuffer"
-
-      CGPROGRAM
-      #pragma vertex vert
-      #pragma fragment frag
-      #pragma multi_compile GBUFFER_DIFFUSE GBUFFER_DEPTH GBUFFER_NORMAL GBUFFER_EMISSION GBUFFER_GLOSSINESS GBUFFER_METALLIC
-
-      #include "UnityCG.cginc"
-
-      struct v2f
-      {
-        float4 vertex : SV_POSITION;
-        float2 uv : TEXCOORD;
-      };
-
-      struct FragmentOutput {
-        half4 color : SV_TARGET;
-        float depth : SV_DEPTH;
-      };
-
-      float4 _MainTex_ST;
-      sampler2D _MainTex;
-      sampler2D Depth;
-      sampler2D Normal;
-      sampler2D Emission;
-      sampler2D Other;
-
-      v2f vert (appdata_base v)
-      {
-        v2f o;
-        o.vertex = UnityObjectToClipPos(v.vertex);
-        o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
-        return o;
-      }
-
-      FragmentOutput frag (v2f i)
-      {
-        FragmentOutput o;
-        o.color = 0.0;
-        o.depth = tex2D(Depth, i.uv).r;
-
-        if (o.depth > 0.0) {
-#if defined(GBUFFER_DIFFUSE)
-          o.color = half4(tex2D(_MainTex, i.uv));
-#elif defined(GBUFFER_DEPTH)
-          float d = sqrt(o.depth);
-          o.color = half4(d, d, d, 1.0);
-#elif defined(GBUFFER_NORMAL)
-          o.color = half4(mad(0.5, tex2D(Normal, i.uv).rgb, 0.5), 1.0);
-#elif defined(GBUFFER_EMISSION)
-          o.color = half4(tex2D(Emission, i.uv).rgb, 1.0);
-#elif defined(GBUFFER_GLOSSINESS)
-          o.color = tex2D(Other, i.uv).r;
-          o.color.a = 1.0;
-#elif defined(GBUFFER_METALLIC)
-          o.color = tex2D(Other, i.uv).g;
-          o.color.a = 1.0;
-#endif
-        }
-
-        return o;
       }
       ENDCG
     }


### PR DESCRIPTION
A while ago, I implemented G-buffer pass and added a few keywords just for visuallizing and debugging. TilI found out that Unity has Frame Debugger, these things are no longer needed anymore.