### PR TITLE
Reorganize G-Buffers

### DIFF
--- a/Shaders/Basic.shader
+++ b/Shaders/Basic.shader
@@ -73,9 +73,9 @@
 
       struct FragmentOutput {
         float4 diffuse   : SV_TARGET0;
-        float3 normal    : SV_TARGET1;
-        float3 emission  : SV_TARGET2;
-        float4 other     : SV_TARGET3;
+        float4 specular  : SV_TARGET1;
+        float3 normal    : SV_TARGET2;
+        float3 emission  : SV_TARGET3;
       };
 
       v2f vert (appdata_tan v)
@@ -99,10 +99,11 @@
         float4 color = _Color * tex2D(_MainTex, i.uv);
 
         float3 localNormal = UnpackScaleNormal(tex2D(_BumpMap, i.uv), _BumpScale);
-        float3 worldNormal;
-        worldNormal.x = dot(i.tangentX, localNormal);
-        worldNormal.y = dot(i.tangentY, localNormal);
-        worldNormal.z = dot(i.tangentZ, localNormal);
+        float3 worldNormal = float3(
+          dot(i.tangentX, localNormal),
+          dot(i.tangentY, localNormal),
+          dot(i.tangentZ, localNormal)
+        );
 
         float glossiness = _SmoothnessTextureChannel > 0.0 ? color.a * _GlossMapScale : _Glossiness;
 
@@ -119,10 +120,10 @@
         #endif
 
         FragmentOutput o;
-        o.diffuse = color;;
-        o.normal = normalize(worldNormal);
+        o.diffuse = color;
+        o.normal = mad(normalize(worldNormal), 0.5, 0.5);
         o.emission = emission;
-        o.other = float4(glossiness, metallic, 0.0, 0.0);
+        o.specular = float4(glossiness, metallic, 0.0, 0.0);
 
         return o;
       }

--- a/Shaders/VXGI.shader
+++ b/Shaders/VXGI.shader
@@ -13,8 +13,6 @@ Shader "Hidden/VXGI"
     {
       Name "ConeTracing"
 
-      Blend SrcAlpha OneMinusSrcAlpha
-
       CGPROGRAM
       #pragma vertex vert
       #pragma fragment frag
@@ -37,9 +35,9 @@ Shader "Hidden/VXGI"
       float3 CameraPosition;
       Texture2D _MainTex;
       Texture2D Depth;
+      Texture2D Specular;
       Texture2D Normal;
       Texture2D Emission;
-      Texture2D Other;
       Texture2D Irradiance;
       float4x4 ClipToWorld;
 
@@ -69,12 +67,12 @@ Shader "Hidden/VXGI"
           float4 worldPosition = mul(ClipToWorld, float4(mad(2.0, i.uv, -1.0), clipZ, 1.0));
           data.worldPosition = worldPosition.xyz / worldPosition.w;
 
-          float2 other = Other.Sample(point_clamp_sampler, i.uv);
+          float2 specular = Specular.Sample(point_clamp_sampler, i.uv);
           data.baseColor = _MainTex.Sample(point_clamp_sampler, i.uv);
-          data.glossiness = other.r;
-          data.metallic = other.g;
+          data.glossiness = specular.r;
+          data.metallic = specular.g;
 
-          data.vecN = Normal.Sample(point_clamp_sampler, i.uv);
+          data.vecN = mad(Normal.Sample(point_clamp_sampler, i.uv), 2.0, -1.0);
           data.vecV = normalize(CameraPosition - data.worldPosition);
 
           data.Initialize();
@@ -135,7 +133,7 @@ Shader "Hidden/VXGI"
           float4 voxel = mul(ClipToVoxel, float4(mad(2.0, i.uv, -1.0), clipZ, 1.0));
           float3 position = voxel.xyz / voxel.w;
 
-          float3 normal = Normal.Sample(point_clamp_sampler, i.uv);
+          float3 normal = mad(Normal.Sample(point_clamp_sampler, i.uv), 2.0, -1.0);
 
           color = float4(IndirectDiffusePixelRadiance(position, normal), 1.0);
         }


### PR DESCRIPTION
I reorganize the G-Buffers to match the [Unity deferred shading implementation](https://docs.unity3d.com/Manual/RenderTech-DeferredShading.html) to make it work nicely with the default Unity shader. Moreover, we can reuse the Unity shader code to generate G-Buffers.