### PR TITLE
Refactor profile sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changed
 
+- Refactor profile sampling.
 - Optimize and refactor `VoxelShader`.
 - Update README.
 - Switch to built-in G-Buffer generator.

--- a/Resources/VXGI/Compute/Mipmapper.compute
+++ b/Resources/VXGI/Compute/Mipmapper.compute
@@ -14,7 +14,7 @@ static float Weights[4] = {
   R_64
 };
 
-[numthreads(8,8,8)]
+[numthreads(4,4,4)]
 void CSFilter(int3 id : SV_DispatchThreadID)
 {
   if (any(id >= DstRes)) return;
@@ -42,7 +42,7 @@ void CSFilter(int3 id : SV_DispatchThreadID)
 
 int3 Displacement;
 
-[numthreads(8,8,8)]
+[numthreads(4,4,4)]
 void CSShift(int3 id : SV_DispatchThreadID)
 {
   if (any(id >= DstRes)) return;

--- a/Runtime/SRP/VXGIRenderPipeline.cs
+++ b/Runtime/SRP/VXGIRenderPipeline.cs
@@ -20,7 +20,7 @@ public class VXGIRenderPipeline : RenderPipeline {
 
   public VXGIRenderPipeline(VXGIRenderPipelineAsset asset) {
     _renderer = new VXGIRenderer(this);
-    _command = new CommandBuffer() { name = "VXGIRenderPipeline" };
+    _command = new CommandBuffer() { name = "VXGI.RenderPipeline" };
     _filterSettings = new FilterRenderersSettings(true) { renderQueueRange = RenderQueueRange.opaque };
 
     _drawRendererFlags = DrawRendererFlags.None;
@@ -50,6 +50,8 @@ public class VXGIRenderPipeline : RenderPipeline {
     BeginFrameRendering(cameras);
 
     foreach (var camera in cameras) {
+      string cameraSample = "Render.Camera." + camera.cameraType.ToString();
+
       var layer = camera.GetComponent<PostProcessLayer>();
 
       if (layer != null && layer.isActiveAndEnabled) {
@@ -65,10 +67,10 @@ public class VXGIRenderPipeline : RenderPipeline {
       if (vxgi != null && vxgi.isActiveAndEnabled) {
         vxgi.Render(renderContext, _renderer);
       } else {
-#if UNITY_EDITOR
         bool rendered = false;
 
-        if (camera.cameraType == UnityEngine.CameraType.SceneView) {
+#if UNITY_EDITOR
+        if (camera.cameraType == CameraType.SceneView) {
           ScriptableRenderContext.EmitWorldGeometryForSceneView(camera);
         }
 
@@ -80,15 +82,13 @@ public class VXGIRenderPipeline : RenderPipeline {
             rendered = true;
           }
         }
+#endif
 
         if (!rendered) RenderFallback(renderContext, camera);
-#else
-        RenderFallback(renderContext, camera);
-#endif
       }
-
-      renderContext.Submit();
     }
+
+    renderContext.Submit();
   }
 
   void RenderFallback(ScriptableRenderContext renderContext, Camera camera) {

--- a/Runtime/Stages/Mipmapper.cs
+++ b/Runtime/Stages/Mipmapper.cs
@@ -11,22 +11,23 @@ public class Mipmapper {
     }
   }
 
+  const string _sampleFilter = "Filter.";
+  const string _sampleShift = "Shift";
+
   int _kernelFilter;
   int _kernelShift;
   int _propDisplacement;
   int _propDst;
   int _propDstRes;
   int _propSrc;
-  CommandBuffer _commandFilter;
-  CommandBuffer _commandShift;
+  CommandBuffer _command;
   ComputeShader _compute;
   VXGI _vxgi;
 
   public Mipmapper(VXGI vxgi) {
     _vxgi = vxgi;
 
-    _commandFilter = new CommandBuffer { name = "Mipmapper.Filter" };
-    _commandShift = new CommandBuffer { name = "Mipmapper.Shift" };
+    _command = new CommandBuffer { name = "VXGI.Mipmapper" };
 
     if (Application.platform == RuntimePlatform.LinuxEditor || Application.platform == RuntimePlatform.LinuxPlayer) {
       _kernelFilter = 1;
@@ -43,46 +44,39 @@ public class Mipmapper {
   }
 
   public void Dispose() {
-    _commandFilter.Dispose();
+    _command.Dispose();
   }
 
   public void Filter(ScriptableRenderContext renderContext) {
-    _commandFilter.BeginSample(_commandFilter.name);
-
     var radiances = _vxgi.radiances;
 
     for (var i = 1; i < radiances.Length; i++) {
       int resolution = radiances[i].volumeDepth;
-      int groups = Mathf.CeilToInt((float)resolution / 8f);
+      int groups = Mathf.CeilToInt((float)resolution / 4f);
 
-      _commandFilter.SetComputeIntParam(compute, _propDstRes, resolution);
-      _commandFilter.SetComputeTextureParam(compute, _kernelFilter, _propDst, radiances[i]);
-      _commandFilter.SetComputeTextureParam(compute, _kernelFilter, _propSrc, radiances[i - 1]);
-      _commandFilter.DispatchCompute(compute, _kernelFilter, groups, groups, groups);
+      _command.BeginSample(_sampleFilter + resolution.ToString());
+      _command.SetComputeIntParam(compute, _propDstRes, resolution);
+      _command.SetComputeTextureParam(compute, _kernelFilter, _propDst, radiances[i]);
+      _command.SetComputeTextureParam(compute, _kernelFilter, _propSrc, radiances[i - 1]);
+      _command.DispatchCompute(compute, _kernelFilter, groups, groups, groups);
+      _command.EndSample(_sampleFilter + resolution.ToString());
     }
 
-    _commandFilter.EndSample(_commandFilter.name);
-
-    renderContext.ExecuteCommandBuffer(_commandFilter);
-
-    _commandFilter.Clear();
+    renderContext.ExecuteCommandBuffer(_command);
+    _command.Clear();
   }
 
   public void Shift(ScriptableRenderContext renderContext, Vector3Int displacement) {
-    _commandShift.BeginSample(_commandShift.name);
+    int groups = Mathf.CeilToInt((float)_vxgi.resolution / 4f);
 
-    int groups = Mathf.CeilToInt((float)_vxgi.resolution / 8f);
-
-    _commandShift.SetComputeIntParam(compute, _propDstRes, (int)_vxgi.resolution);
-    _commandShift.SetComputeIntParams(compute, _propDisplacement, new[] { displacement.x, displacement.y, displacement.z });
-    _commandShift.SetComputeTextureParam(compute, _kernelShift, _propDst, _vxgi.radiances[0]);
-    _commandShift.DispatchCompute(compute, _kernelShift, groups, groups, groups);
-
-    _commandShift.EndSample(_commandShift.name);
-
-    renderContext.ExecuteCommandBuffer(_commandShift);
-
-    _commandShift.Clear();
+    _command.BeginSample(_sampleShift);
+    _command.SetComputeIntParam(compute, _propDstRes, (int)_vxgi.resolution);
+    _command.SetComputeIntParams(compute, _propDisplacement, new[] { displacement.x, displacement.y, displacement.z });
+    _command.SetComputeTextureParam(compute, _kernelShift, _propDst, _vxgi.radiances[0]);
+    _command.DispatchCompute(compute, _kernelShift, groups, groups, groups);
+    _command.EndSample(_sampleShift);
+    renderContext.ExecuteCommandBuffer(_command);
+    _command.Clear();
 
     Filter(renderContext);
   }

--- a/Runtime/Stages/Voxelizer.cs
+++ b/Runtime/Stages/Voxelizer.cs
@@ -20,7 +20,7 @@ public class Voxelizer : System.IDisposable {
   public Voxelizer(VXGI vxgi) {
     _vxgi = vxgi;
 
-    _command = new CommandBuffer { name = "Voxelizer" };
+    _command = new CommandBuffer { name = "VXGI.Voxelizer" };
     _rect = new Rect(0f, 0f, 1f, 1f);
 
     _propDummyTarget = Shader.PropertyToID("DummyTarget");

--- a/Runtime/VXGI.cs
+++ b/Runtime/VXGI.cs
@@ -96,14 +96,14 @@ public class VXGI : MonoBehaviour {
   }
 
   public void Render(ScriptableRenderContext renderContext, Camera camera, VXGIRenderer renderer) {
+    _command.BeginSample(_command.name);
+    renderContext.ExecuteCommandBuffer(_command);
+    _command.Clear();
+
     UpdateResolution();
 
     float realtime = Time.realtimeSinceStartup;
     bool tracingThrottled = throttleTracing;
-
-#if UNITY_EDITOR
-    tracingThrottled &= UnityEditor.EditorApplication.isPlaying;
-#endif
 
     if (tracingThrottled) {
       if (_previousTrace + 1f / tracingRate < realtime) {
@@ -135,6 +135,11 @@ public class VXGI : MonoBehaviour {
     }
 
     _lights.Clear();
+
+    _command.EndSample(_command.name);
+    renderContext.ExecuteCommandBuffer(_command);
+    _command.Clear();
+
   }
 
   void PrePass(ScriptableRenderContext renderContext, VXGIRenderer renderer) {
@@ -176,7 +181,7 @@ public class VXGI : MonoBehaviour {
     _resolution = (int)resolution;
 
     _camera = GetComponent<Camera>();
-    _command = new CommandBuffer { name = "VXGI" };
+    _command = new CommandBuffer { name = "VXGI.MonoBehaviour" };
     _lights = new List<LightSource>(64);
     _lightSources = new ComputeBuffer(64, LightSource.size);
     _mipmapper = new Mipmapper(this);


### PR DESCRIPTION
I find out the weird behaviour of profiler sampling using `CommandBuffer` (Unity 2018):

```cs
CommandBuffer command = new CommandBuffer { name = "Command Name" };
ScriptableRenderContext context;

// Works
command.BeginSample("Something");
command.EndSample("Something");
context.ExecuteCommandBuffer(command);

// Fails
command.BeginSample("Something");
context.ExecuteCommandBuffer(command);
command.Clear();
command.EndSample("Something");
context.ExecuteCommandBuffer(command);

// Works
command.BeginSample(command.name);
context.ExecuteCommandBuffer(command);
command.Clear();
command.EndSample(command.name);
context.ExecuteCommandBuffer(command);
```