### PR TITLE
Fix light injection when throttling cone tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,6 @@
 
 ### Fixed
 
+- Fix light injection when throttling cone tracing.
 - Fix light source injection.
 - Fix inverted `GrabCopy` pass.

--- a/Runtime/SRP/VXGIRenderPipeline.cs
+++ b/Runtime/SRP/VXGIRenderPipeline.cs
@@ -50,8 +50,6 @@ public class VXGIRenderPipeline : RenderPipeline {
     BeginFrameRendering(cameras);
 
     foreach (var camera in cameras) {
-      string cameraSample = "Render.Camera." + camera.cameraType.ToString();
-
       var layer = camera.GetComponent<PostProcessLayer>();
 
       if (layer != null && layer.isActiveAndEnabled) {

--- a/Runtime/Stages/Voxelizer.cs
+++ b/Runtime/Stages/Voxelizer.cs
@@ -46,6 +46,8 @@ public class Voxelizer : System.IDisposable {
     if (!CullResults.GetCullingParameters(_camera, out cullingParams)) return;
     CullResults.Cull(ref cullingParams, renderContext, ref _cullResults);
 
+    _vxgi.lights.Clear();
+
     foreach (var light in _cullResults.visibleLights) {
       if (VXGI.supportedLightTypes.Contains(light.lightType) && light.finalColor.maxColorComponent > 0f) {
         _vxgi.lights.Add(new LightSource(light, _vxgi.worldToVoxel));

--- a/Runtime/VXGI.cs
+++ b/Runtime/VXGI.cs
@@ -134,8 +134,6 @@ public class VXGI : MonoBehaviour {
       renderer.RenderDeferred(renderContext, camera, this);
     }
 
-    _lights.Clear();
-
     _command.EndSample(_command.name);
     renderContext.ExecuteCommandBuffer(_command);
     _command.Clear();


### PR DESCRIPTION
Do not clear light list right after rendering, as throttled cone tracing doesn't voxelize the scene for some other frames, at which light list is not populated. This results in the lights in the scene flickering.

Instead, clear the light list right before adding new lights to the list.